### PR TITLE
Fix for relative urls and html entities in urls

### DIFF
--- a/lib/link_readability.js
+++ b/lib/link_readability.js
@@ -24,6 +24,15 @@ ReadableLinks.parse = function(links, callback){
   var resultLinks = [];
 
   async.map(links, function(link, finish){
+    link.url = require("entities").decode(link.url);
+
+    if (link.url.indexOf('://') == -1) {
+      console.log("Not trying: " + link.url);
+      link.url = "http://news.ycombinator.com/" + link.url;
+      resultLinks.push(link);
+      finish();
+      return;
+    }
 
     // parsed before
     redis.get(link.url, function(err, reply){
@@ -40,7 +49,9 @@ ReadableLinks.parse = function(links, callback){
         Readability.get(link.url,'html', function(result){
 
           if(result.error) {
-            console.log("ERROR" + result.text);
+            console.log("ERROR for URL " + link.url + " : " + result.text);
+            resultLinks.push(link);
+            finish();
             return;
           }
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "htmlparser2": "~3.0.5",
     "should": "~1.2.2",
     "rss": "0.0.4",
-    "express": "~3.2.4"
+    "express": "~3.2.4",
+    "entities": "0.3.0"
   }
 }


### PR DESCRIPTION
I made a few changes to stop failures caused by relative urls to news.ycombinator .com and html entities in urls. Additionally if a link fails I still push it to the result with a basic link and title (and don't put it in Redis).

You can see my version running on here: http://hn-rss.herokuapp.com/

I love the project!

James
